### PR TITLE
feat: add configurable exclude_dirs for repo map generation

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -141,10 +141,20 @@ templates:
     - ARCHITECTURE_GUIDELINES.md
     - CODING_GUIDELINES.md
     - AGENT_OBJECTIVITY.md
+  exclude_dirs:
+    - .git
+    - .mypy_cache
+    - .ruff_cache
+    - .venv
+    - .idea
+    - __pycache__
+    - .codeteam
+    - node_modules
 ```
 
 Configures template rendering:
 - **guideline_files**: List of guideline files to load and make available to all agents
+- **exclude_dirs**: List of directories to exclude from the repository map generation. This helps reduce the size of the repository map passed to AI agents, which can prevent "Argument list too long" errors on large projects
 
 ## Customization Examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "code-team-framework"
-version = "0.1.0"
+version = "0.1.1"
 description = "A framework for AI-powered software development using a team of specialized agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/code_team/__init__.py
+++ b/src/code_team/__init__.py
@@ -9,5 +9,5 @@ from .models.config import CodeTeamConfig
 from .models.plan import Plan
 from .orchestrator.orchestrator import Orchestrator
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __all__ = ["CodeTeamConfig", "Plan", "Orchestrator"]

--- a/src/code_team/models/config.py
+++ b/src/code_team/models/config.py
@@ -85,6 +85,19 @@ class TemplateConfig(BaseModel):
             "AGENT_OBJECTIVITY.md",
         ]
     )
+    exclude_dirs: list[str] = Field(
+        default_factory=lambda: [
+            ".git",
+            ".mypy_cache",
+            ".ruff_cache",
+            ".venv",
+            ".idea",
+            "__pycache__",
+            ".codeteam",
+            "node_modules",
+            "build",
+        ]
+    )
 
 
 class CodeTeamConfig(BaseModel):

--- a/src/code_team/orchestrator/orchestrator.py
+++ b/src/code_team/orchestrator/orchestrator.py
@@ -36,6 +36,7 @@ class Orchestrator:
             project_root / self.config.paths.template_dir,
             project_root=project_root,
             guideline_files=self.config.templates.guideline_files,
+            exclude_dirs=self.config.templates.exclude_dirs,
         )
 
         self._ensure_dirs_exist()

--- a/src/code_team/utils/filesystem.py
+++ b/src/code_team/utils/filesystem.py
@@ -28,6 +28,7 @@ def get_repo_map(root: Path, exclude_dirs: list[str] | None = None) -> str:
             "__pycache__",
             ".codeteam",
             "node_modules",
+            "build",
         ]
 
     lines: list[str] = []

--- a/src/code_team/utils/templates.py
+++ b/src/code_team/utils/templates.py
@@ -107,6 +107,7 @@ class TemplateManager:
         template_dir: Path,
         project_root: Path | None = None,
         guideline_files: list[str] | None = None,
+        exclude_dirs: list[str] | None = None,
     ):
         self._loader = HybridTemplateLoader(template_dir, "code_team", "templates")
         self._env = Environment(loader=self._loader)
@@ -116,6 +117,7 @@ class TemplateManager:
             "CODING_GUIDELINES.md",
             "AGENT_OBJECTIVITY.md",
         ]
+        self._exclude_dirs = exclude_dirs
 
     def render(self, template_name: str, **kwargs: Any) -> str:
         """Render a template with the given context."""
@@ -129,7 +131,9 @@ class TemplateManager:
 
         # Generate repo map content dynamically if project_root is available
         if self._project_root:
-            common_context["REPO_MAP"] = get_repo_map(self._project_root)
+            common_context["REPO_MAP"] = get_repo_map(
+                self._project_root, self._exclude_dirs
+            )
 
         return template.render({**common_context, **kwargs})
 

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -9,6 +9,7 @@ from code_team.models.config import (
     CodeTeamConfig,
     LLMConfig,
     PathConfig,
+    TemplateConfig,
     VerificationCommand,
     VerificationConfig,
     VerificationMetrics,
@@ -206,6 +207,7 @@ class TestCodeTeamConfig:
         assert isinstance(config.verification, VerificationConfig)
         assert isinstance(config.verifier_instances, VerifierInstances)
         assert isinstance(config.paths, PathConfig)
+        assert isinstance(config.templates, TemplateConfig)
 
     def test_custom_config(self) -> None:
         """Test that CodeTeamConfig accepts custom values."""
@@ -233,3 +235,53 @@ class TestCodeTeamConfig:
         assert len(config.verification.commands) == 1
         assert config.verifier_instances.security == 1
         assert config.paths.plan_dir == "custom/plans"
+
+
+class TestTemplateConfig:
+    """Test the TemplateConfig model."""
+
+    def test_default_template_config(self) -> None:
+        """Test that TemplateConfig has correct defaults."""
+        config = TemplateConfig()
+        assert config.guideline_files == [
+            "ARCHITECTURE_GUIDELINES.md",
+            "CODING_GUIDELINES.md",
+            "AGENT_OBJECTIVITY.md",
+        ]
+        assert config.exclude_dirs == [
+            ".git",
+            ".mypy_cache",
+            ".ruff_cache",
+            ".venv",
+            ".idea",
+            "__pycache__",
+            ".codeteam",
+            "node_modules",
+            "build",
+        ]
+
+    def test_custom_template_config(self) -> None:
+        """Test that TemplateConfig accepts custom values."""
+        config = TemplateConfig(
+            guideline_files=["CUSTOM_GUIDELINES.md"],
+            exclude_dirs=["custom_exclude", "another_exclude"],
+        )
+        assert config.guideline_files == ["CUSTOM_GUIDELINES.md"]
+        assert config.exclude_dirs == ["custom_exclude", "another_exclude"]
+
+    def test_empty_exclude_dirs(self) -> None:
+        """Test that TemplateConfig accepts empty exclude_dirs list."""
+        config = TemplateConfig(exclude_dirs=[])
+        assert config.exclude_dirs == []
+
+    def test_partial_custom_config(self) -> None:
+        """Test that TemplateConfig allows partial customization."""
+        config = TemplateConfig(exclude_dirs=["only_this"])
+        # guideline_files should still be default
+        assert config.guideline_files == [
+            "ARCHITECTURE_GUIDELINES.md",
+            "CODING_GUIDELINES.md",
+            "AGENT_OBJECTIVITY.md",
+        ]
+        # exclude_dirs should be custom
+        assert config.exclude_dirs == ["only_this"]


### PR DESCRIPTION
- Add exclude_dirs field to TemplateConfig with sensible defaults
- Update TemplateManager to accept and use configurable exclude_dirs
- Modify get_repo_map calls to pass custom exclude directories
- Add comprehensive tests for new functionality
- Update documentation with exclude_dirs configuration

This fixes 'Argument list too long' errors on large projects by allowing users to exclude problematic directories like node_modules from the repository map generation.